### PR TITLE
🧹 Refactor duplicate missing package check into helper function

### DIFF
--- a/R/renv_helpers.R
+++ b/R/renv_helpers.R
@@ -102,6 +102,14 @@
   return(lockfile_path)
 }
 
+# Internal helper to check which packages are missing
+.get_missing_pkgs <- function(pkgs) {
+  if (length(pkgs) == 0L) return(character(0))
+  pkgs[!vapply(pkgs, function(x) {
+    requireNamespace(sub("^.*/", "", x), quietly = TRUE)
+  }, logical(1))]
+}
+
 # Extract package names from a DESCRIPTION-style dependency field value.
 # Handles entries like "curl (>= 5.1.0)" or plain "mime", returning
 # only the package name without version constraints.
@@ -515,11 +523,7 @@ skip_if_dep_unavailable will be ignored."
   .renv_install(pkg_remaining, biocmanager_install, is_bioc)
 
   # Check again for any packages that failed to install
-  pkg_still_missing <- pkg_remaining[
-    !sapply(pkg_remaining, function(x) {
-      requireNamespace(sub("^.*/", "", x), quietly = TRUE)
-    })
-  ]
+  pkg_still_missing <- .get_missing_pkgs(pkg_remaining)
 
   if (length(pkg_still_missing) == 0L) {
     cli::cli_alert_success("All remaining packages installed successfully.")
@@ -566,11 +570,7 @@ skip_if_dep_unavailable will be ignored."
   }
 
   # Final check
-  pkg_final_missing <- pkg_still_missing[
-    !sapply(pkg_still_missing, function(x) {
-      requireNamespace(sub("^.*/", "", x), quietly = TRUE)
-    })
-  ]
+  pkg_final_missing <- .get_missing_pkgs(pkg_still_missing)
 
   if (length(pkg_final_missing) == 0L) {
     cli::cli_alert_success(

--- a/tests/testthat/test-helpers.R
+++ b/tests/testthat/test-helpers.R
@@ -35,6 +35,39 @@ test_that(".renv_paths_lockfile function exists", {
   expect_true(is.function(renvvv:::.renv_paths_lockfile))
 })
 
+# Test .get_missing_pkgs
+test_that(".get_missing_pkgs function exists", {
+  expect_true(is.function(renvvv:::.get_missing_pkgs))
+})
+
+test_that(".get_missing_pkgs handles empty vector", {
+  expect_equal(renvvv:::.get_missing_pkgs(character(0)), character(0))
+})
+
+test_that(".get_missing_pkgs correctly identifies missing packages", {
+  # Base packages should be available
+  expect_equal(renvvv:::.get_missing_pkgs(c("base", "utils")), character(0))
+
+  # A definitely missing package
+  missing_pkg <- "definitely_not_a_package_12345"
+  expect_equal(renvvv:::.get_missing_pkgs(missing_pkg), missing_pkg)
+
+  # Mixture of present and missing
+  expect_equal(
+    renvvv:::.get_missing_pkgs(c("base", missing_pkg)),
+    missing_pkg
+  )
+})
+
+test_that(".get_missing_pkgs handles remotes", {
+  missing_gh <- "user/definitely_not_a_package_12345"
+  expect_equal(renvvv:::.get_missing_pkgs(missing_gh), missing_gh)
+
+  # If we have a package installed that we refer to via remote
+  # (using 'cli' as it should be there for the tests)
+  expect_equal(renvvv:::.get_missing_pkgs("r-lib/cli"), character(0))
+})
+
 test_that(".renv_paths_lockfile returns default path", {
   # Clear environment variables
   old_lockfile <- Sys.getenv("RENV_PATHS_LOCKFILE", unset = NA)


### PR DESCRIPTION
The duplicate `sapply` logic to check `requireNamespace` at lines 518 and 569 of `R/renv_helpers.R` has been extracted into a `.get_missing_pkgs(pkgs)` helper function, following DRY principles. Added unit tests for the new helper.

---
*PR created automatically by Jules for task [9039410627010573723](https://jules.google.com/task/9039410627010573723) started by @MiguelRodo*