### PR TITLE
🔒 [security fix] Fix potential code injection in cli::cli_alert_* formatting

### DIFF
--- a/R/renv_helpers.R
+++ b/R/renv_helpers.R
@@ -173,8 +173,9 @@ skip_if_dep_unavailable will be ignored."
     cli::cli_alert_warning(
       paste0(
         "Could not extract package dependencies from lockfile ",
-        "(skip_if_dep_unavailable ignored): {e$message}"
-      )
+        "(skip_if_dep_unavailable ignored): {msg}"
+      ),
+      msg = e$message
     )
     list()
   })
@@ -341,7 +342,8 @@ skip_if_dep_unavailable will be ignored."
       renv::restore(packages = pkg_names, transactional = FALSE),
       error = function(e) {
         cli::cli_alert_danger(
-          "Failed to restore {pkg_type} packages: {.pkg {pkg_names}}. Error: {e$message}"
+          "Failed to restore {pkg_type} packages: {.pkg {pkg_names}}. Error: {msg}",
+          msg = e$message
         )
       }
     )
@@ -417,7 +419,8 @@ skip_if_dep_unavailable will be ignored."
         renv::restore(packages = x, transactional = FALSE),
         error = function(e) {
           cli::cli_alert_danger(
-            "Failed to restore package: {.pkg {x}}. Error: {e$message}"
+            "Failed to restore package: {.pkg {x}}. Error: {msg}",
+            msg = e$message
           )
         }
       )
@@ -447,7 +450,8 @@ skip_if_dep_unavailable will be ignored."
           renv::install(paste0("bioc::", pkg), prompt = FALSE),
           error = function(e) {
             cli::cli_alert_danger(
-              "Failed to install Bioconductor packages via renv: {.pkg {pkg}}. Error: {e$message}"
+              "Failed to install Bioconductor packages via renv: {.pkg {pkg}}. Error: {msg}",
+              msg = e$message
             )
           }
         )
@@ -459,7 +463,8 @@ skip_if_dep_unavailable will be ignored."
           BiocManager::install(pkg, update = TRUE, ask = FALSE),
           error = function(e) {
             cli::cli_alert_danger(
-              "Failed to install Bioconductor packages using BiocManager: {.pkg {pkg}}. Error: {e$message}"
+              "Failed to install Bioconductor packages using BiocManager: {.pkg {pkg}}. Error: {msg}",
+              msg = e$message
             )
           }
         )
@@ -472,7 +477,8 @@ skip_if_dep_unavailable will be ignored."
         renv::install(paste0("bioc::", pkg), prompt = FALSE),
         error = function(e) {
           cli::cli_alert_danger(
-            "Failed to install Bioconductor packages via renv: {.pkg {pkg}}. Error: {e$message}"
+            "Failed to install Bioconductor packages via renv: {.pkg {pkg}}. Error: {msg}",
+            msg = e$message
           )
         }
       )
@@ -483,7 +489,8 @@ skip_if_dep_unavailable will be ignored."
       renv::install(pkg, prompt = FALSE),
       error = function(e) {
         cli::cli_alert_danger(
-          "Failed to install packages: {.pkg {pkg}}. Error: {e$message}"
+          "Failed to install packages: {.pkg {pkg}}. Error: {msg}",
+          msg = e$message
         )
       }
     )


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed was potential code injection in `cli::cli_alert_*` functions within `R/renv_helpers.R`.

⚠️ **Risk:** `cli` functions use `glue` under the hood, which evaluates expressions in curly braces `{}`. If an error message (`e$message`) from an external source contained malicious code in curly braces, it could potentially be executed if interpolated directly into the template string.

🛡️ **Solution:** The fix involves passing `e$message` as a named argument to the `cli` functions (e.g., `cli_alert_danger("... Error: {msg}", msg = e$message)`). This ensures the content is treated as a literal value and prevents recursive interpolation or execution of code within the error message itself.

---
*PR created automatically by Jules for task [4827694230130830540](https://jules.google.com/task/4827694230130830540) started by @MiguelRodo*