### PR TITLE
Fix unused argument error in cli_alert_danger/warning

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: renvvv
 Title: Robust 'renv' Package Restore and Update Functions
-Version: 0.1.1
+Version: 0.1.2
 Authors@R:
     person("Miguel", "Rodo", , "rdxmig002@myuct.ac.za", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-2036-4878"))

--- a/R/renv_helpers.R
+++ b/R/renv_helpers.R
@@ -178,11 +178,10 @@ skip_if_dep_unavailable will be ignored."
     )
     list()
   }, error = function(e) {
-    msg <- e$message
     cli::cli_alert_warning(
       paste0(
         "Could not extract package dependencies from lockfile ",
-        "(skip_if_dep_unavailable ignored): {msg}"
+        "(skip_if_dep_unavailable ignored): {e$message}"
       )
     )
     list()
@@ -349,9 +348,8 @@ skip_if_dep_unavailable will be ignored."
     tryCatch(
       renv::restore(packages = pkg_names, transactional = FALSE),
       error = function(e) {
-        msg <- e$message
         cli::cli_alert_danger(
-          "Failed to restore {pkg_type} packages: {.pkg {pkg_names}}. Error: {msg}"
+          "Failed to restore {pkg_type} packages: {.pkg {pkg_names}}. Error: {e$message}"
         )
       }
     )
@@ -426,9 +424,8 @@ skip_if_dep_unavailable will be ignored."
       tryCatch(
         renv::restore(packages = x, transactional = FALSE),
         error = function(e) {
-          msg <- e$message
           cli::cli_alert_danger(
-            "Failed to restore package: {.pkg {x}}. Error: {msg}"
+            "Failed to restore package: {.pkg {x}}. Error: {e$message}"
           )
         }
       )
@@ -457,9 +454,8 @@ skip_if_dep_unavailable will be ignored."
         tryCatch(
           renv::install(paste0("bioc::", pkg), prompt = FALSE),
           error = function(e) {
-            msg <- e$message
             cli::cli_alert_danger(
-              "Failed to install Bioconductor packages via renv: {.pkg {pkg}}. Error: {msg}"
+              "Failed to install Bioconductor packages via renv: {.pkg {pkg}}. Error: {e$message}"
             )
           }
         )
@@ -470,9 +466,8 @@ skip_if_dep_unavailable will be ignored."
         tryCatch(
           BiocManager::install(pkg, update = TRUE, ask = FALSE),
           error = function(e) {
-            msg <- e$message
             cli::cli_alert_danger(
-              "Failed to install Bioconductor packages using BiocManager: {.pkg {pkg}}. Error: {msg}"
+              "Failed to install Bioconductor packages using BiocManager: {.pkg {pkg}}. Error: {e$message}"
             )
           }
         )
@@ -484,9 +479,8 @@ skip_if_dep_unavailable will be ignored."
       tryCatch(
         renv::install(paste0("bioc::", pkg), prompt = FALSE),
         error = function(e) {
-          msg <- e$message
           cli::cli_alert_danger(
-            "Failed to install Bioconductor packages via renv: {.pkg {pkg}}. Error: {msg}"
+            "Failed to install Bioconductor packages via renv: {.pkg {pkg}}. Error: {e$message}"
           )
         }
       )
@@ -496,9 +490,8 @@ skip_if_dep_unavailable will be ignored."
     tryCatch(
       renv::install(pkg, prompt = FALSE),
       error = function(e) {
-        msg <- e$message
         cli::cli_alert_danger(
-          "Failed to install packages: {.pkg {pkg}}. Error: {msg}"
+          "Failed to install packages: {.pkg {pkg}}. Error: {e$message}"
         )
       }
     )

--- a/R/renv_helpers.R
+++ b/R/renv_helpers.R
@@ -178,12 +178,12 @@ skip_if_dep_unavailable will be ignored."
     )
     list()
   }, error = function(e) {
+    msg <- e$message
     cli::cli_alert_warning(
       paste0(
         "Could not extract package dependencies from lockfile ",
         "(skip_if_dep_unavailable ignored): {msg}"
-      ),
-      msg = e$message
+      )
     )
     list()
   })
@@ -349,9 +349,9 @@ skip_if_dep_unavailable will be ignored."
     tryCatch(
       renv::restore(packages = pkg_names, transactional = FALSE),
       error = function(e) {
+        msg <- e$message
         cli::cli_alert_danger(
-          "Failed to restore {pkg_type} packages: {.pkg {pkg_names}}. Error: {msg}",
-          msg = e$message
+          "Failed to restore {pkg_type} packages: {.pkg {pkg_names}}. Error: {msg}"
         )
       }
     )
@@ -426,9 +426,9 @@ skip_if_dep_unavailable will be ignored."
       tryCatch(
         renv::restore(packages = x, transactional = FALSE),
         error = function(e) {
+          msg <- e$message
           cli::cli_alert_danger(
-            "Failed to restore package: {.pkg {x}}. Error: {msg}",
-            msg = e$message
+            "Failed to restore package: {.pkg {x}}. Error: {msg}"
           )
         }
       )
@@ -457,9 +457,9 @@ skip_if_dep_unavailable will be ignored."
         tryCatch(
           renv::install(paste0("bioc::", pkg), prompt = FALSE),
           error = function(e) {
+            msg <- e$message
             cli::cli_alert_danger(
-              "Failed to install Bioconductor packages via renv: {.pkg {pkg}}. Error: {msg}",
-              msg = e$message
+              "Failed to install Bioconductor packages via renv: {.pkg {pkg}}. Error: {msg}"
             )
           }
         )
@@ -470,9 +470,9 @@ skip_if_dep_unavailable will be ignored."
         tryCatch(
           BiocManager::install(pkg, update = TRUE, ask = FALSE),
           error = function(e) {
+            msg <- e$message
             cli::cli_alert_danger(
-              "Failed to install Bioconductor packages using BiocManager: {.pkg {pkg}}. Error: {msg}",
-              msg = e$message
+              "Failed to install Bioconductor packages using BiocManager: {.pkg {pkg}}. Error: {msg}"
             )
           }
         )
@@ -484,9 +484,9 @@ skip_if_dep_unavailable will be ignored."
       tryCatch(
         renv::install(paste0("bioc::", pkg), prompt = FALSE),
         error = function(e) {
+          msg <- e$message
           cli::cli_alert_danger(
-            "Failed to install Bioconductor packages via renv: {.pkg {pkg}}. Error: {msg}",
-            msg = e$message
+            "Failed to install Bioconductor packages via renv: {.pkg {pkg}}. Error: {msg}"
           )
         }
       )
@@ -496,9 +496,9 @@ skip_if_dep_unavailable will be ignored."
     tryCatch(
       renv::install(pkg, prompt = FALSE),
       error = function(e) {
+        msg <- e$message
         cli::cli_alert_danger(
-          "Failed to install packages: {.pkg {pkg}}. Error: {msg}",
-          msg = e$message
+          "Failed to install packages: {.pkg {pkg}}. Error: {msg}"
         )
       }
     )

--- a/tests/testthat/test-error_handling.R
+++ b/tests/testthat/test-error_handling.R
@@ -1,0 +1,27 @@
+test_that("error handlers are triggered correctly when packages fail", {
+  # Mock renv::install and renv::restore to always throw errors
+  mockery::stub(renvvv:::.renv_restore_remaining, "renv::restore", function(...) stop("Mocked restore error"))
+  mockery::stub(renvvv:::.renv_install_remaining, "renv::install", function(...) stop("Mocked install error"))
+  mockery::stub(renvvv:::.renv_install_remaining, "BiocManager::install", function(...) stop("Mocked BiocManager install error"))
+
+  # Execute a deliberately failing restore
+  expect_error(
+    renvvv:::.renv_restore_remaining("non_existent_pkg_1"),
+    NA # we expect it to swallow the error internally and continue
+  )
+
+  # Execute deliberately failing installs
+  expect_error(
+    renvvv:::.renv_install_remaining("non_existent_pkg_2", biocmanager_install = FALSE, is_bioc = FALSE),
+    NA
+  )
+  expect_error(
+    renvvv:::.renv_install_remaining("non_existent_pkg_bioc", biocmanager_install = TRUE, is_bioc = TRUE),
+    NA
+  )
+  expect_error(
+    renvvv:::.renv_install_remaining("non_existent_pkg_bioc_renv", biocmanager_install = FALSE, is_bioc = TRUE),
+    NA
+  )
+
+})


### PR DESCRIPTION
Fixes a crash when updating where the `tryCatch` block threw an unused argument error when calling `cli_alert_danger(msg = e$message)`.

---
*PR created automatically by Jules for task [8528712176473852040](https://jules.google.com/task/8528712176473852040) started by @MiguelRodo*