### PR TITLE
🧪 [Test Improvement] Add expect_message test for renv::restore tryCatch block

### DIFF
--- a/tests/testthat/test-error_handling.R
+++ b/tests/testthat/test-error_handling.R
@@ -4,10 +4,13 @@ test_that("error handlers are triggered correctly when packages fail", {
   mockery::stub(renvvv:::.renv_install_remaining, "renv::install", function(...) stop("Mocked install error"))
   mockery::stub(renvvv:::.renv_install_remaining, "BiocManager::install", function(...) stop("Mocked BiocManager install error"))
 
-  # Execute a deliberately failing restore
-  expect_error(
-    renvvv:::.renv_restore_remaining("non_existent_pkg_1"),
-    NA # we expect it to swallow the error internally and continue
+  # Execute a deliberately failing restore and verify the expected message
+  expect_message(
+    expect_error(
+      renvvv:::.renv_restore_remaining("non_existent_pkg_1"),
+      NA # we expect it to swallow the error internally and continue
+    ),
+    "Failed to restore package: .*non_existent_pkg_1.*Error: Mocked restore error"
   )
 
   # Execute deliberately failing installs


### PR DESCRIPTION
🎯 **What:** Added missing test coverage for the tryCatch block in `.renv_restore_remaining` that handles failures from `renv::restore`.
📊 **Coverage:** The test suite now explicitly covers the failure path of individual package restoration to confirm it properly logs an error via `cli_alert_danger` without halting execution entirely.
✨ **Result:** Improved test coverage and reliability of error-handling mechanics in package restoration flow.

---
*PR created automatically by Jules for task [15428154105602265746](https://jules.google.com/task/15428154105602265746) started by @MiguelRodo*