### PR TITLE
🧪 Add test coverage for BiocManager install error handler

### DIFF
--- a/tests/testthat/test-error_handling.R
+++ b/tests/testthat/test-error_handling.R
@@ -25,3 +25,32 @@ test_that("error handlers are triggered correctly when packages fail", {
   )
 
 })
+
+test_that(".renv_install error handler for BiocManager works", {
+  # Mock requireNamespace to pretend BiocManager is installed, and cli is available
+  mockery::stub(.renv_install, "requireNamespace", function(pkg, ...) {
+    if (pkg == "BiocManager" || pkg == "cli") return(TRUE)
+    return(FALSE)
+  })
+
+  # Mock BiocManager::install to throw an error
+  mock_install <- function(...) stop("Mocked BiocManager install error")
+  mockery::stub(.renv_install, "BiocManager::install", mock_install)
+
+  # Mock cli_alert_danger to capture its call
+  mock_danger <- mockery::mock()
+  mockery::stub(.renv_install, "cli::cli_alert_danger", mock_danger)
+
+  # Execute deliberately failing install through .renv_install
+  expect_error(
+    .renv_install("fake_bioc_pkg", biocmanager_install = TRUE, is_bioc = TRUE),
+    NA
+  )
+
+  # Verify that cli::cli_alert_danger was called correctly
+  mockery::expect_called(mock_danger, 1)
+
+  # Verify the arguments passed to cli_alert_danger contained our message
+  args <- mockery::mock_args(mock_danger)[[1]]
+  expect_match(args[[1]], "Failed to install Bioconductor packages using BiocManager")
+})


### PR DESCRIPTION
🎯 **What:** Added missing test coverage for the `tryCatch` error handling block when `BiocManager::install` fails inside `.renv_install`.
📊 **Coverage:** The test explicitly mocks `requireNamespace` and `BiocManager::install` to simulate an installation failure, ensuring `tryCatch` gracefully catches the error. It also stubs `cli::cli_alert_danger` to verify the correct error message is output.
✨ **Result:** Improved test coverage for Bioconductor package installation fallback logic. Tested the side-effects to guarantee that failures are properly reported to the CLI without halting the execution.

---
*PR created automatically by Jules for task [15041131383933886498](https://jules.google.com/task/15041131383933886498) started by @MiguelRodo*